### PR TITLE
encodings_fragment deprecated in three.js

### DIFF
--- a/src/LineMaterial.js
+++ b/src/LineMaterial.js
@@ -409,7 +409,7 @@ THREE.ShaderLib[ 'line' ] = {
 			gl_FragColor = vec4( diffuseColor.rgb, alpha );
 
 			#include <tonemapping_fragment>
-			#include <encodings_fragment>
+			#include <colorspace_fragment>
 			#include <fog_fragment>
 			#include <premultiplied_alpha_fragment>
 


### PR DESCRIPTION
encodings_fragment have been deprecated and this breaks flatline under three.js version 0.164.1